### PR TITLE
Modified redisd to notify for eth0 ip change,issue 80

### DIFF
--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -126,6 +126,19 @@ func Connect() (redis.Conn, error) {
 	return redis.NewConn(conn, rdtimeout, wrtimeout), nil
 }
 
+func NotifyRedisIfMgtIpChange(itfname string,address string)(err error){
+	conn, err := Connect()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	_,err = conn.Do("LISTENONNEWIP",itfname,address)
+	if err != nil{
+		return
+	}
+	return
+}
+
 func Get(key string) (s string, err error) {
 	conn, err := Connect()
 	if err != nil {


### PR DESCRIPTION
Event is generated in netlink.go and it is notified to redisd for eth0 ip change.Old connection is closed.

Before change =
siddhant@invader41:~$ netstat -nlp | grep 6379
(Not all processes could be identified, non-owned process info
will not be shown, you would have to be root to see it all.)
tcp 0 0 172.17.2.31:6379 0.0.0.0:* LISTEN -
tcp 0 0 127.0.0.1:6379 0.0.0.0:* LISTEN -
tcp6 0 0 fe80::5218:4cff:fe:6379 :::* LISTEN -
tcp6 0 0 ::1:6379 :::* LISTEN -

After change=
siddhant@invader41:~$ netstat -nlp | grep 6379
(Not all processes could be identified, non-owned process info
will not be shown, you would have to be root to see it all.)
tcp 0 0 172.17.2.95:6379 0.0.0.0:* LISTEN -
tcp 0 0 127.0.0.1:6379 0.0.0.0:* LISTEN -
tcp6 0 0 fe80::5218:4cff:fe:6379 :::* LISTEN -
tcp6 0 0 ::1:6379 :::* LISTEN -

Connect through redis-cli from i29 with changed ip.
siddhant@invader29:~$ redis-cli -h 172.17.2.95
172.17.2.95:6379>